### PR TITLE
[코드 추가] Redis Cache 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     // poi - excel
     implementation 'org.apache.poi:poi:5.2.3'
     implementation 'org.apache.poi:poi-ooxml:5.2.3'
+
+    // redis cache
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/eng/config/RedisConfig.java
+++ b/src/main/java/com/eng/config/RedisConfig.java
@@ -1,0 +1,51 @@
+package com.eng.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Configuration
+@EnableCaching // 캐시 기능 활성화
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public CacheManager cacheManager() {
+        // 자정까지 남은 시간을 계산
+        LocalTime midnight = LocalTime.MIDNIGHT;
+        Duration ttl = Duration.between(LocalDateTime.now(), LocalDateTime.now().toLocalDate().atTime(midnight).plusDays(1));
+
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(ttl); // 자정까지 남은 시간을 TTL로 설정
+
+        return RedisCacheManager.builder(redisConnectionFactory())
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
+}

--- a/src/main/java/com/eng/controller/StudyController.java
+++ b/src/main/java/com/eng/controller/StudyController.java
@@ -3,7 +3,6 @@ package com.eng.controller;
 import com.eng.dto.StudyResponseDto;
 import com.eng.service.StudyService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/eng/domain/Study.java
+++ b/src/main/java/com/eng/domain/Study.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -28,18 +30,23 @@ public class Study {
     @JoinColumn(name = "meaning_id")
     private Meaning meaning;
 
+    @Column
+    private LocalDate date;
+
     @Builder
-    private Study(User user, Word word, Meaning meaning) {
+    private Study(User user, Word word, Meaning meaning, LocalDate date) {
         this.user = user;
         this.word = word;
         this.meaning = meaning;
+        this.date = date;
     }
 
-    public static Study createStudy(User user, Word word, Meaning meaning) {
+    public static Study createStudy(User user, Word word, Meaning meaning, LocalDate date) {
         return Study.builder()
                 .user(user)
                 .word(word)
                 .meaning(meaning)
+                .date(date)
                 .build();
     }
 }

--- a/src/main/java/com/eng/repository/SentenceRepository.java
+++ b/src/main/java/com/eng/repository/SentenceRepository.java
@@ -8,4 +8,7 @@ public interface SentenceRepository extends JpaRepository<Sentence, Long> {
     @Query(nativeQuery = true, value = "SELECT EXISTS " +
             "(SELECT 1 FROM Sentence s WHERE s.meaning_id = :meaningId AND s.sentence = :sentence)")
     int existsByMeanAndSentence(Long meaningId, String sentence);
+
+    @Query("select st from Sentence st where st.meaning.id = :meaningId")
+    Sentence findBySentence(Long meaningId);
 }

--- a/src/main/java/com/eng/repository/StudyRepository.java
+++ b/src/main/java/com/eng/repository/StudyRepository.java
@@ -2,6 +2,15 @@ package com.eng.repository;
 
 import com.eng.domain.Study;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface StudyRepository extends JpaRepository<Study, Long> {
+    @Query("SELECT max(s.date) FROM Study s")
+    LocalDate findLastDay();
+
+    @Query("select s from Study s where s.date = :today")
+    List<Study> findLastDayForStudy(LocalDate today);
 }

--- a/src/main/java/com/eng/service/StudyService.java
+++ b/src/main/java/com/eng/service/StudyService.java
@@ -2,18 +2,23 @@ package com.eng.service;
 
 import com.eng.domain.Meaning;
 import com.eng.domain.Sentence;
+import com.eng.domain.Study;
 import com.eng.domain.User;
 import com.eng.dto.StudyResponseDto;
 import com.eng.exception.notfound.UserNotFoundException;
 import com.eng.repository.MeanRepository;
+import com.eng.repository.SentenceRepository;
+import com.eng.repository.StudyRepository;
 import com.eng.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,23 +28,46 @@ import java.util.List;
 public class StudyService {
     private final UserRepository userRepository;
     private final MeanRepository meanRepository;
+    private final StudyRepository studyRepository;
+    private final SentenceRepository sentenceRepository;
 
     // 단어 가져오기
+    @Cacheable(key="#username", value = "getStudyWord", unless = "#result==null", cacheManager = "cacheManager")
     public List<StudyResponseDto> getStudyWord(String username) {
-        User user = userRepository.findByUsername(username).orElseThrow(UserNotFoundException::new);
-        Pageable pageable = PageRequest.of(0, 10);
-        Page<Object[]> results = meanRepository.findByMeanForStudyWithSentence(user.getId(), pageable);
+        List<Study> studyList = new ArrayList<>();
         List<StudyResponseDto> list = new ArrayList<>();
-        for (Object[] result : results) {
-            Meaning meaning = (Meaning) result[0];
-            Sentence sentence = (Sentence) result[1];
-            list.add(StudyResponseDto.of(
-                    meaning.getWord().getWord(),
-                    meaning.getMeaning(),
-                    sentence.getSentence(),
-                    sentence.getSentence_meaning(),
-                    sentence.getLevel()
-            ));
+        LocalDate date = studyRepository.findLastDay();
+        LocalDate today = LocalDate.now();
+        if(date==null || !date.isEqual(today)){ // 오늘 날짜가 아니라면 학습하지 않은 데이터 10개 조회
+            User user = userRepository.findByUsername(username).orElseThrow(UserNotFoundException::new);
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<Object[]> results = meanRepository.findByMeanForStudyWithSentence(user.getId(), pageable);
+            for (Object[] result : results) {
+                Meaning meaning = (Meaning) result[0];
+                Sentence sentence = (Sentence) result[1];
+                studyList.add(Study.createStudy(user,meaning.getWord(), meaning, today));
+                list.add(StudyResponseDto.of(
+                        meaning.getWord().getWord(),
+                        meaning.getMeaning(),
+                        sentence.getSentence(),
+                        sentence.getSentence_meaning(),
+                        sentence.getLevel()
+                ));
+            }
+            // study에 데이터 저장하기
+            studyRepository.saveAll(studyList);
+        }else{ // 오늘 날짜라면 Study 테이블에서 조회
+            List<Study> study = studyRepository.findLastDayForStudy(today);
+            for(Study st : study){
+                Sentence sentence = sentenceRepository.findBySentence(st.getMeaning().getId());
+                list.add(StudyResponseDto.of(
+                        st.getWord().getWord(),
+                        st.getMeaning().getMeaning(),
+                        sentence.getSentence(),
+                        sentence.getSentence_meaning(),
+                        sentence.getLevel()
+                ));
+            }
         }
         return list;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,11 @@
 spring.application.name=eng
 spring.profiles.include=private
+
+# Redis Cache
+spring.cache.type = redis
+
+# redis docker
+spring.data.redis.host = host.docker.internal
+spring.data.redis.port = 6379
+# null cache y/n
+spring.cache.redis.cache-null-values=false

--- a/src/main/resources/static/js/study.js
+++ b/src/main/resources/static/js/study.js
@@ -14,7 +14,10 @@ function getStudyWords() {
             contentType: false,
             processData: false,
             success: function (response) {
-                localStorage.setItem(username,JSON.stringify(response));
+                const now = new Date();
+                const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 0); // 다음 날 자정
+                const ttl = midnight.getTime() - now.getTime(); // 밀리초 단위 남은 시간
+                setTTL(username,JSON.stringify(response), ttl)
                 cards = response;
                 let temp = `
             <h5 class="card-title english-text" id="wordTitle">${response[0]["word"]}</h5>
@@ -30,6 +33,17 @@ function getStudyWords() {
         })
     }
 }
+
+// 만료 시간 설정 (하루에서 남은 시간)
+function setTTL(username, value, ttl){
+    const expiry = Date.now() + ttl; // 현재 날짜 + TTL(ms)
+    const item = {
+        value, // 저장할 데이터
+        expiry // 만료 시간
+    };
+    localStorage.setItem(username, JSON.stringify(item));
+}
+
 let currentName = username+"page";
 let currentCard = localStorage.getItem(currentName)?localStorage.getItem(currentName):0;
 // studyModal 요소 선택
@@ -37,5 +51,8 @@ const studyModal = document.getElementById("studyModal");
 
 // 모달이 닫힐 때 localStorage에 저장하는 EventListener 추가
 studyModal.addEventListener("hidden.bs.modal", () => {
-    localStorage.setItem(currentName, currentCard);
+    const now = new Date();
+    const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1, 0, 0, 0); // 다음 날 자정
+    const ttl = midnight.getTime() - now.getTime(); // 밀리초 단위 남은 시간
+    setTTL(currentName, currentCard, ttl)
 });


### PR DESCRIPTION
- 학습하기 method 호출 시 10개의 단어를 캐싱하고 `Study` 테이블에 해당 단어들을 저장 

- `@Cacheable`의 TTL을 오늘 자정까지 남은 시간으로 설정

- 만약 cache 값이 없거나 서버가 재시작 되면서 새로운 단어를 10개 가져오는 것을 방지하기 위해       
    `Study` 테이블에서 가장 최근 날짜가 오늘인 경우 `Study` 테이블에서 단어 목록 조회         

- js에서도 해당 단어 목록들을 localStorage에 저장할 때 ttl을 추가하여 
   하루가 지나면 해당 기록들은 사라지고 다시 서버에 요청을 해오는 것으로 수정   